### PR TITLE
Fix Angular CLI dependency version

### DIFF
--- a/bin/dev_setup
+++ b/bin/dev_setup
@@ -27,7 +27,7 @@ nodeenv --node=6.11.1 --prebuilt venv
 source venv/bin/activate
 
 echo "Installing npm dependencies..."
-npm install -g @angular/cli node-sass
+npm install -g @angular/cli@">=1.5.6 <2.0.0" node-sass
 deactivate_node
 
 echo "Installing local node modules..."

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ng2-ace": "0.0.15"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.5",
+    "@angular/cli": "^1.5.6",
     "@angular/compiler-cli": "5.0.1",
     "@angular/language-service": "5.0.1",
     "@types/jasmine": "2.6.3",
@@ -52,6 +52,6 @@
     "protractor": "5.2.0",
     "ts-node": "3.3.0",
     "tslint": "5.8.0",
-    "typescript": "^2.4.2"
+    "typescript": "~2.4.2"
   }
 }


### PR DESCRIPTION
An "emergency patch" to the angular devkit broke several builds of angular-cli. As a result, when trying to run the `sawtooth-explorer` project with `ng serve` for the first time after installing dependencies, users were getting the following error in output:

`Error: Cannot find module '@angular-devkit/core'`

This MR updates angular-cli to apply their fix for this, and changes the dependency to allow for patches and minor updates. It also updates the `dev_setup` script so that the global version of `angular-cli` installed will match the project version. Last, the `typescript` dependency has been changed so that it will meet the required version range for `angular-cli`.

Issue referenced here: https://github.com/angular/angular-cli/issues/9276