### PR TITLE
fix nginx config to support options and route spa

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -36,6 +36,8 @@ http {
         listen 8090;
         add_header Pragma no-cache always;
         add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods 'GET, OPTIONS';
+        add_header Access-Control-Allow-Headers 'X-XSRF-TOKEN,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
 
         location / {
           proxy_pass          http://host.docker.internal:8008;
@@ -51,7 +53,7 @@ http {
 
         location / {
             root /www/ste;
-            try_files $uri $uri.html $uri/index.html index.html;
+            try_files $uri $uri.html $uri/index.html /index.html;
         }
     }
 }


### PR DESCRIPTION
- need two additional headers to accept `OPTIONS` requests, which are sent by browsers, and `X-XSRF-TOKEN` header.
- need a `/` in front of index.html to make nginx route SPA requests to index.html

Probably these fixes are required because explorer uses latest nginx Docker image