### PR TITLE
Fix @types/lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "5.0.1",
     "@angular/platform-browser-dynamic": "5.0.1",
     "@angular/router": "5.0.1",
-    "@types/lodash": "^4.14.85",
+    "@types/lodash": "4.14.49",
     "angular2-moment": "1.7.0",
     "core-js": "2.5.1",
     "crypto-js": "3.1.9-1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "skipLibCheck": true,
     "target": "es5",
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
When trying to do:
npm run start

There are many errors with "@types/lodash": "^4.14.85":

ERROR in node_modules/@types/lodash/common/array.d.ts(37,24): error TS1005: ';' expected.
node_modules/@types/lodash/common/array.d.ts(483,22): error TS1005: ';' expected.
node_modules/@types/lodash/common/array.d.ts(483,41): error TS1005: ',' expected.

ERROR in node_modules/@types/lodash/index.d.ts(19300,15): error TS2428: All declarations of 'WeakMap' must have identical type parameters.
node_modules/typescript/lib/lib.es2015.collection.d.ts(45,11): error TS2428: All declarations of 'WeakMap' must have identical type parameters.
node_modules/typescript/lib/lib.es2015.iterable.d.ts(157,11): error TS2428: All declarations of 'WeakMap' must have identical type parameters.
node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts(133,11): error TS2428: All declarations of 'WeakMap' must have identical type parameters.

This pull request has the solution outlined in: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324